### PR TITLE
base: Fix proximity check on non power key

### DIFF
--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -5648,7 +5648,8 @@ public class PhoneWindowManager implements WindowManagerPolicy {
         if (isValidGlobalKey(keyCode)
                 && mGlobalKeyManager.shouldHandleGlobalKey(keyCode, event)) {
             if (isWakeKey) {
-                wakeUp(event.getEventTime(), mAllowTheaterModeWakeFromKey, "android.policy:KEY");
+                wakeUp(event.getEventTime(), mAllowTheaterModeWakeFromKey,
+                       "android.policy:KEY", true);
             }
             return result;
         }
@@ -5986,7 +5987,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
         }
 
         if (isWakeKey) {
-            wakeUp(event.getEventTime(), mAllowTheaterModeWakeFromKey, "android.policy:KEY");
+            wakeUp(event.getEventTime(), mAllowTheaterModeWakeFromKey, "android.policy:KEY", true);
         }
 
         return result;


### PR DESCRIPTION
To test, enable "Settings >> Display >> Prevent accidental wake-up"
and "Settings >> Buttons >> Home button Wake up device", hold your
hand over the proximity sensor and turn your phone on by home key.

Prior to this change, it will wake up the phone and after the change
it will not.

Change-Id: Ifd14ff2ad9cd2cbc64209b9cf19e3c0ee0b6f40f