### PR TITLE
SystemUI: Improve string in data capable, not selected scenario.

### DIFF
--- a/packages/SystemUI/res/values/cm_strings.xml
+++ b/packages/SystemUI/res/values/cm_strings.xml
@@ -258,4 +258,7 @@
         <item quantity="one">%1$d client</item>
         <item quantity="other">%1$d clients</item>
     </plurals>
+
+    <!-- CellularTile data sim not configured state string -->
+    <string name="data_sim_not_configured">No data SIM</string>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/CellularTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/CellularTile.java
@@ -147,7 +147,9 @@ public class CellularTile extends QSTile<QSTile.SignalState> {
 
         state.label = cb.enabled
                 ? removeTrailingPeriod(cb.enabledDesc)
-                : r.getString(R.string.quick_settings_rssi_emergency_only);
+                : mDataController.isMobileDataSupported() ?
+                r.getString(R.string.data_sim_not_configured) :
+                r.getString(R.string.quick_settings_rssi_emergency_only);
 
         final String signalContentDesc = cb.enabled && (cb.mobileSignalIconId > 0)
                 ? cb.signalContentDescription
@@ -232,10 +234,14 @@ public class CellularTile extends QSTile<QSTile.SignalState> {
                 // Make sure signal gets cleared out when no sims.
                 mInfo.mobileSignalIconId = 0;
                 mInfo.dataTypeIconId = 0;
-                // Show a No SIMs description to avoid emergency calls message.
+                // Show a No SIMs description if we're incapable of supporting mobile data
+                // to avoid showing an emergency mode description. If we're still capable of
+                // supporting mobile data, notify the user that the data sim is not configured
+                // only relevant in MSIM scenario: CYNGNOS-2211
                 mInfo.enabled = true;
-                mInfo.enabledDesc = mContext.getString(
-                        R.string.keyguard_missing_sim_message_short);
+                mInfo.enabledDesc = mDataController.isMobileDataSupported() ?
+                        mContext.getString(R.string.data_sim_not_configured)
+                        : mContext.getString(R.string.keyguard_missing_sim_message_short);
                 mInfo.signalContentDescription = mInfo.enabledDesc;
             }
             refreshState(mInfo);


### PR DESCRIPTION
  If a user hotswaps out their SIMs on a multisim device, the
  default data sim can be in an "unset" state. Since this is
  a possible scenario, its better to show that no data sim
  is selected vs no sims being available.

Change-Id: I1e077883472a5037f38f97e6d15afe504f787e6a
TICKET: CYNGNOS-2211