### PR TITLE
SysUI: Clear notification data when recreating status bar

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -3733,14 +3733,8 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         int nNotifs = mNotificationData.size();
         ArrayList<Pair<String, StatusBarNotification>> notifications = new ArrayList<>(nNotifs);
         copyNotifications(notifications, mNotificationData);
-        // now remove all the notification views since we'll be re-inflating these with the copied
-        // data
-        for (int i = 0; i < nNotifs; i++) {
-            final NotificationData.Entry entry = mNotificationData.get(i);
-            if (entry != null) {
-                removeNotificationViews(entry.key, rankingMap);
-            }
-        }
+        // now remove all the notifications since we'll be re-creating these with the copied data
+        mNotificationData.clear();
 
         if (mCustomTileListenerService != null) {
             try {


### PR DESCRIPTION
This ensures we don't get an IndexOutOfBounds exception  in
StatusBarIconController when adding the notifications back in.

Change-Id: I70ffd487223f95642ccdb41e9e5a3dde3ba6990d
TICKET: CYNGNOS-2215